### PR TITLE
Add convenience functions to add uint32 to sysex7

### DIFF
--- a/inc/midi/sysex.h
+++ b/inc/midi/sysex.h
@@ -194,6 +194,9 @@ struct sysex7 : sysex
     void     add_uint28(uint28_t);
     uint28_t make_uint28(size_t data_pos) const;
 
+    void     add_uint32(uint32_t);
+    uint28_t make_uint32(size_t data_pos) const;
+
     void            add_device_identity(const device_identity&);
     device_identity make_device_identity(size_t data_pos) const;
 
@@ -283,6 +286,22 @@ inline uint28_t sysex7::make_uint28(size_t data_pos) const
 {
     assert(data_pos + 3 < data.size());
     return data[data_pos] | (data[data_pos + 1] << 7) | (data[data_pos + 2] << 14) | (data[data_pos + 3] << 21);
+}
+
+inline void sysex7::add_uint32(uint32_t value)
+{
+    const uint7_t d[] = { uint7_t(value & 0x7Fu),
+                          uint7_t((value >> 7) & 0x7Fu),
+                          uint7_t((value >> 14) & 0x7Fu),
+                          uint7_t((value >> 21) & 0x7Fu),
+                          uint7_t((value >> 28) & 0x0Fu)};
+    data.insert(data.end(), d, d + sizeof(d));
+}
+
+inline uint32_t sysex7::make_uint32(size_t data_pos) const
+{
+    assert(data_pos + 4 < data.size());
+    return data[data_pos] | (data[data_pos + 1] << 7) | (data[data_pos + 2] << 14) | (data[data_pos + 3] << 21) | ((data[data_pos + 4] & 0x0F) << 28) ;
 }
 
 //--------------------------------------------------------------------------

--- a/tests/sysex_tests.cpp
+++ b/tests/sysex_tests.cpp
@@ -341,6 +341,82 @@ TEST_F(sysex, sysex7_add_uintX)
         EXPECT_EQ(127u, sx.data[26]);
         EXPECT_EQ(127u, sx.data[27]);
     }
+
+    {
+        midi::sysex7 sx{ 0x123456 };
+
+        sx.add_uint32(0);
+        EXPECT_EQ(5u, sx.data.size());
+        EXPECT_EQ(0u, sx.data[0]);
+        EXPECT_EQ(0u, sx.data[1]);
+        EXPECT_EQ(0u, sx.data[2]);
+        EXPECT_EQ(0u, sx.data[3]);
+        EXPECT_EQ(0u, sx.data[4]);
+        EXPECT_EQ(0, sx.make_uint32(0u));
+
+        sx.add_uint32(99);
+        EXPECT_EQ(10u, sx.data.size());
+        EXPECT_EQ(99u, sx.data[5]);
+        EXPECT_EQ(0u, sx.data[6]);
+        EXPECT_EQ(0u, sx.data[7]);
+        EXPECT_EQ(0u, sx.data[8]);
+        EXPECT_EQ(0u, sx.data[9]);
+        EXPECT_EQ(99, sx.make_uint32(5u));
+
+        sx.add_uint32(128);
+        EXPECT_EQ(15u, sx.data.size());
+        EXPECT_EQ(0u, sx.data[10]);
+        EXPECT_EQ(1u, sx.data[11]);
+        EXPECT_EQ(0u, sx.data[12]);
+        EXPECT_EQ(0u, sx.data[13]);
+        EXPECT_EQ(0u, sx.data[14]);
+        EXPECT_EQ(128, sx.make_uint32(10u));
+
+        sx.add_uint32(0x3FFF);
+        EXPECT_EQ(20u, sx.data.size());
+        EXPECT_EQ(127u, sx.data[15]);
+        EXPECT_EQ(127u, sx.data[16]);
+        EXPECT_EQ(0u, sx.data[17]);
+        EXPECT_EQ(0u, sx.data[18]);
+        EXPECT_EQ(0u, sx.data[19]);
+        EXPECT_EQ(0x3FFF, sx.make_uint32(15u));
+
+        sx.add_uint32(0x123456);
+        EXPECT_EQ(25u, sx.data.size());
+        EXPECT_EQ(0x56u, sx.data[20]);
+        EXPECT_EQ(0x68u, sx.data[21]);
+        EXPECT_EQ(0x48u, sx.data[22]);
+        EXPECT_EQ(0u, sx.data[23]);
+        EXPECT_EQ(0u, sx.data[24]);
+        EXPECT_EQ(0x123456, sx.make_uint32(20u));
+
+        sx.add_uint32(0x1234567);
+        EXPECT_EQ(30u, sx.data.size());
+        EXPECT_EQ(0x67u, sx.data[25]);
+        EXPECT_EQ(0x0Au, sx.data[26]);
+        EXPECT_EQ(0x0Du, sx.data[27]);
+        EXPECT_EQ(0x09u, sx.data[28]);
+        EXPECT_EQ(0u, sx.data[29]);
+        EXPECT_EQ(0x1234567, sx.make_uint32(25u));
+
+        sx.add_uint32(0x0FFFFFFF);
+        EXPECT_EQ(35u, sx.data.size());
+        EXPECT_EQ(127u, sx.data[30]);
+        EXPECT_EQ(127u, sx.data[31]);
+        EXPECT_EQ(127u, sx.data[32]);
+        EXPECT_EQ(127u, sx.data[33]);
+        EXPECT_EQ(0u, sx.data[34]);
+        EXPECT_EQ(0x0FFFFFFF, sx.make_uint32(30u));
+
+        sx.add_uint32(0xFFFFFFFF);
+        EXPECT_EQ(40u, sx.data.size());
+        EXPECT_EQ(127u, sx.data[35]);
+        EXPECT_EQ(127u, sx.data[36]);
+        EXPECT_EQ(127u, sx.data[37]);
+        EXPECT_EQ(127u, sx.data[38]);
+        EXPECT_EQ(0x0Fu, sx.data[39]);
+        EXPECT_EQ(0xFFFFFFFF, sx.make_uint32(35u));
+    }
 }
 
 //-----------------------------------------------


### PR DESCRIPTION
Sometimes we need to transport a full width 32 bit value over 5 sysex7 bytes