### PR TITLE
Mixed Data Set support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.12.0
+
+* add _Mixed Data Set_ support: `mixed_data_set_header_packet` / `mixed_data_set_payload_packet` incl. views and factory functions
+* add `mixed_data_set` with `send_mixed_data_set` / `as_mixed_data_set_packets`
+* add `mixed_data_set_collector` reassembling _Mixed Data Sets_ from incoming packets (16 simultaneous `mds_id`s)
+
 # v1.11.0
 
 * add data_byte accessors to `flex_data_message_view`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ set(LibSources
     inc/midi/data_message.h
     inc/midi/extended_data_message.h
     inc/midi/flex_data_message.h
+    inc/midi/mixed_data_set.h
+    inc/midi/mixed_data_set_collector.h src/mixed_data_set_collector.cpp
     inc/midi/stream_message.h
     inc/midi/sysex.h src/sysex.cpp
     inc/midi/sysex_collector.h src/sysex_collector.cpp
@@ -91,6 +93,9 @@ if( NIMIDI2_TESTS )
         tests/data_message_tests.cpp
         tests/extended_data_message_tests.cpp
         tests/flex_data_message_tests.cpp
+        tests/mixed_data_set_tests.cpp
+        tests/mixed_data_set_test_data.cpp tests/mixed_data_set_test_data.h
+        tests/mixed_data_set_collector_tests.cpp
         tests/stream_message_tests.cpp
         tests/system_message_tests.cpp
         tests/utility_message_tests.cpp
@@ -136,6 +141,7 @@ if( NIMIDI2_EXAMPLES )
         docs/data_message.examples.cpp
         docs/extended_data_message.examples.cpp
         docs/flex_data_message.examples.cpp
+        docs/mixed_data_set.examples.cpp
         docs/midi1_byte_stream.examples.cpp
         docs/midi1_channel_voice_message.examples.cpp
         docs/midi2_channel_voice_message.examples.cpp

--- a/docs/docs.cpp
+++ b/docs/docs.cpp
@@ -2,6 +2,7 @@ extern void run_channel_voice_message_examples();
 extern void run_data_message_examples();
 extern void run_extended_data_message_examples();
 extern void run_flex_data_message_examples();
+extern void run_mixed_data_set_examples();
 extern void run_midi1_byte_stream_examples();
 extern void run_midi1_channel_voice_message_examples();
 extern void run_midi2_channel_voice_message_examples();
@@ -29,6 +30,7 @@ int main()
 
     run_stream_message_examples();
     run_flex_data_message_examples();
+    run_mixed_data_set_examples();
 
     return 0;
 }

--- a/docs/mixed_data_set.examples.cpp
+++ b/docs/mixed_data_set.examples.cpp
@@ -1,0 +1,51 @@
+#include <midi/manufacturer.h>
+#include <midi/mixed_data_set.h>
+#include <midi/mixed_data_set_collector.h>
+
+#include <cassert>
+
+void mixed_data_set_examples()
+{
+    using namespace midi;
+
+    // a mixed data set with some payload data
+    mixed_data_set mds{ manufacturer::native_instruments, 0, 0, 0 };
+    mds.data = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+
+    for (const auto& p : as_mixed_data_set_packets(mds, 0x0))
+    {
+        // send packet
+        // ...
+        (void)p;
+    }
+
+    // or send packets without allocating a vector
+    send_mixed_data_set(mds, 0x0, 0, [](const universal_packet& p) {
+        // send packet
+        // ...
+        (void)p;
+    });
+}
+
+void mixed_data_set_collector_examples()
+{
+    using namespace midi;
+
+    universal_packet p;
+
+    mixed_data_set_collector c{ [](const mixed_data_set& mds, uint4_t mds_id) {
+        // do something with message
+        // ...
+        (void)mds;
+        (void)mds_id;
+    } };
+
+    if (is_mixed_data_set_packet(p))
+        c.feed(p);
+}
+
+void run_mixed_data_set_examples()
+{
+    mixed_data_set_examples();
+    mixed_data_set_collector_examples();
+}

--- a/docs/mixed_data_set.md
+++ b/docs/mixed_data_set.md
@@ -1,0 +1,100 @@
+# Mixed Data Set
+
+Code examples can be found in [`mixed_data_set.examples.cpp`](mixed_data_set.examples.cpp).
+
+_Mixed Data Set_ messages allow transfer of arbitrary (8 bit) data, the data being
+split into _chunks_, each chunk consisting of a _header_ packet followed by _payload_
+packets (14 data bytes per packet). Up to 16 _Mixed Data Sets_ (distinguished by
+their `mds_id`) can be transmitted simultaneously within a group.
+
+A complete _Mixed Data Set_ is represented by
+
+```cpp
+struct mixed_data_set
+{
+    using data_type = std::vector<uint8_t>;
+
+    manufacturer_t manufacturerID;
+    uint16_t       deviceID;       // 0xFFFF means 'all call'
+    uint16_t       subID1;
+    uint16_t       subID2;
+    data_type      data;
+
+    mixed_data_set(manufacturer_t);
+    mixed_data_set(manufacturer_t, uint16_t device_id, uint16_t sub_id_1, uint16_t sub_id_2);
+    mixed_data_set(manufacturer_t, uint16_t device_id, uint16_t sub_id_1, uint16_t sub_id_2, data_type);
+
+    void clear();
+};
+```
+
+Like in _System Exclusive_ messages, `deviceID`, `subID1` and `subID2` are defined by
+other MMA/AMEI specifications when `manufacturerID` is a Universal SysEx ID, otherwise
+their use is defined by the manufacturer.
+
+On the wire the manufacturer ID is encoded in 16 bits, conversions are available as
+
+```cpp
+constexpr uint16_t       mixed_data_set_manufacturer_id(manufacturer_t);
+constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t);
+```
+
+## Message Creation and Filtering
+
+Individual packets are represented by `mixed_data_set_header_packet` and
+`mixed_data_set_payload_packet` (in `extended_data_message.h`), with corresponding
+factory functions, filters and views:
+
+```cpp
+mixed_data_set_header_packet  make_mixed_data_set_header_packet(uint4_t mds_id, group_t = 0);
+mixed_data_set_payload_packet make_mixed_data_set_payload_packet(uint4_t mds_id, group_t = 0);
+
+bool is_mixed_data_set_header_packet(const universal_packet&);
+bool is_mixed_data_set_payload_packet(const universal_packet&);
+bool is_mixed_data_set_packet(const universal_packet&);
+
+std::optional<mixed_data_set_header_packet_view>  as_mixed_data_set_header_packet_view(const universal_packet&);
+std::optional<mixed_data_set_payload_packet_view> as_mixed_data_set_payload_packet_view(const universal_packet&);
+```
+
+## Sending Mixed Data Sets
+
+Usually one does not create _Mixed Data Set_ packets manually, but uses
+
+```cpp
+template<typename Sender>
+void send_mixed_data_set(const mixed_data_set&, uint4_t mds_id, group_t, Sender&&);
+
+std::vector<extended_data_message> as_mixed_data_set_packets(const mixed_data_set&, uint4_t mds_id, group_t = 0);
+```
+
+`send_mixed_data_set` splits the data into chunks and packets and forwards them to
+`sender(p)`. `as_mixed_data_set_packets` returns the resulting packets in a vector
+instead.
+
+## Collecting Mixed Data Sets
+
+Use `mixed_data_set_collector` to reassemble _Mixed Data Sets_ from incoming packets:
+
+```cpp
+class mixed_data_set_collector
+{
+public:
+    using callback = std::function<void(const mixed_data_set&, uint4_t mds_id)>;
+
+    explicit mixed_data_set_collector(callback);
+
+    void set_callback(callback);
+    void set_max_data_size(size_t); // limit maximum size of accepted mixed data set data
+
+    void feed(const universal_packet&);
+    void reset();
+};
+```
+
+Feed incoming packets into `feed()`. Once the final chunk of a _Mixed Data Set_ is
+complete the callback is invoked with the reassembled `mixed_data_set` and its
+`mds_id`. The collector maintains an independent collection state per `mds_id`, so
+interleaved _Mixed Data Sets_ are supported. Aborted messages (a header with
+_Number of this Chunk_ set to zero), out-of-order chunks and invalid headers discard
+the collection state of the affected `mds_id`.

--- a/docs/mixed_data_set.md
+++ b/docs/mixed_data_set.md
@@ -32,11 +32,12 @@ Like in _System Exclusive_ messages, `deviceID`, `subID1` and `subID2` are defin
 other MMA/AMEI specifications when `manufacturerID` is a Universal SysEx ID, otherwise
 their use is defined by the manufacturer.
 
-On the wire the manufacturer ID is encoded in 16 bits, conversions are available as
+On the wire the manufacturer ID is encoded in 16 bits, conversions are available
+in `manufacturer.h` as
 
 ```cpp
-constexpr uint16_t       mixed_data_set_manufacturer_id(manufacturer_t);
-constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t);
+constexpr uint16_t       manufacturer_id_16bit(manufacturer_t);
+constexpr manufacturer_t manufacturer_from_16bit_id(uint16_t);
 ```
 
 ## Message Creation and Filtering

--- a/inc/midi/extended_data_message.h
+++ b/inc/midi/extended_data_message.h
@@ -69,8 +69,70 @@ struct sysex8_packet : extended_data_message
 
 //--------------------------------------------------------------------------
 
+struct mixed_data_set_header_packet : extended_data_message
+{
+    constexpr mixed_data_set_header_packet();
+    constexpr mixed_data_set_header_packet(uint4_t mds_id, group_t);
+    ~mixed_data_set_header_packet() = default;
+
+    constexpr uint4_t mds_id() const { return status() & 0x0F; }
+    constexpr void    set_mds_id(uint4_t);
+
+    constexpr uint16_t valid_bytes_in_chunk() const { return make_uint16(2); }
+    constexpr void     set_valid_bytes_in_chunk(uint16_t v) { set_uint16(2, v); }
+
+    constexpr uint16_t nr_of_chunks() const { return make_uint16(4); }
+    constexpr void     set_nr_of_chunks(uint16_t v) { set_uint16(4, v); }
+
+    constexpr uint16_t chunk_nr() const { return make_uint16(6); }
+    constexpr void     set_chunk_nr(uint16_t v) { set_uint16(6, v); }
+
+    constexpr uint16_t manufacturer_id() const { return make_uint16(8); }
+    constexpr void     set_manufacturer_id(uint16_t v) { set_uint16(8, v); }
+
+    constexpr uint16_t device_id() const { return make_uint16(10); }
+    constexpr void     set_device_id(uint16_t v) { set_uint16(10, v); }
+
+    constexpr uint16_t sub_id_1() const { return make_uint16(12); }
+    constexpr void     set_sub_id_1(uint16_t v) { set_uint16(12, v); }
+
+    constexpr uint16_t sub_id_2() const { return make_uint16(14); }
+    constexpr void     set_sub_id_2(uint16_t v) { set_uint16(14, v); }
+
+  private:
+    constexpr uint16_t make_uint16(size_t b) const { return uint16_t((get_byte(b) << 8) | get_byte(b + 1)); }
+    constexpr void     set_uint16(size_t b, uint16_t v)
+    {
+        set_byte(b, uint8_t(v >> 8));
+        set_byte(b + 1, uint8_t(v & 0xFF));
+    }
+};
+
+//--------------------------------------------------------------------------
+
+struct mixed_data_set_payload_packet : extended_data_message
+{
+    constexpr mixed_data_set_payload_packet();
+    constexpr mixed_data_set_payload_packet(uint4_t mds_id, group_t);
+    ~mixed_data_set_payload_packet() = default;
+
+    constexpr uint4_t mds_id() const { return status() & 0x0F; }
+    constexpr void    set_mds_id(uint4_t);
+
+    //! a mixed data set payload packet always carries 14 payload bytes
+    static constexpr size_t payload_size = 14;
+
+    constexpr uint8_t payload_byte(size_t b) const { return get_byte(2 + b); }
+    constexpr void    set_payload_byte(size_t, uint8_t);
+};
+
+//--------------------------------------------------------------------------
+
 constexpr bool is_extended_data_message(const universal_packet&);
 constexpr bool is_sysex8_packet(const universal_packet&);
+constexpr bool is_mixed_data_set_header_packet(const universal_packet&);
+constexpr bool is_mixed_data_set_payload_packet(const universal_packet&);
+constexpr bool is_mixed_data_set_packet(const universal_packet&);
 
 //--------------------------------------------------------------------------
 
@@ -98,10 +160,66 @@ constexpr std::optional<sysex8_packet_view> as_sysex8_packet_view(const universa
 
 //--------------------------------------------------------------------------
 
+struct mixed_data_set_header_packet_view
+{
+    constexpr explicit mixed_data_set_header_packet_view(const universal_packet& ump)
+      : p(ump)
+    {
+        assert(is_mixed_data_set_header_packet(ump));
+    }
+
+    constexpr group_t  group() const { return p.group(); }
+    constexpr uint4_t  mds_id() const { return p.status() & 0x0F; }
+    constexpr uint16_t valid_bytes_in_chunk() const { return make_uint16(2); }
+    constexpr uint16_t nr_of_chunks() const { return make_uint16(4); }
+    constexpr uint16_t chunk_nr() const { return make_uint16(6); }
+    constexpr uint16_t manufacturer_id() const { return make_uint16(8); }
+    constexpr uint16_t device_id() const { return make_uint16(10); }
+    constexpr uint16_t sub_id_1() const { return make_uint16(12); }
+    constexpr uint16_t sub_id_2() const { return make_uint16(14); }
+
+  private:
+    constexpr uint16_t make_uint16(size_t b) const { return uint16_t((p.get_byte(b) << 8) | p.get_byte(b + 1)); }
+
+    const universal_packet& p;
+};
+
+//--------------------------------------------------------------------------
+
+struct mixed_data_set_payload_packet_view
+{
+    constexpr explicit mixed_data_set_payload_packet_view(const universal_packet& ump)
+      : p(ump)
+    {
+        assert(is_mixed_data_set_payload_packet(ump));
+    }
+
+    constexpr group_t group() const { return p.group(); }
+    constexpr uint4_t mds_id() const { return p.status() & 0x0F; }
+    constexpr uint8_t payload_byte(size_t b) const { return p.get_byte(2 + b); }
+
+  private:
+    const universal_packet& p;
+};
+
+//--------------------------------------------------------------------------
+
+constexpr std::optional<mixed_data_set_header_packet_view> as_mixed_data_set_header_packet_view(
+  const universal_packet&);
+constexpr std::optional<mixed_data_set_payload_packet_view> as_mixed_data_set_payload_packet_view(
+  const universal_packet&);
+
+//--------------------------------------------------------------------------
+
 constexpr sysex8_packet make_sysex8_complete_packet(uint8_t stream_id, group_t = 0);
 constexpr sysex8_packet make_sysex8_start_packet(uint8_t stream_id, group_t = 0);
 constexpr sysex8_packet make_sysex8_continue_packet(uint8_t stream_id, group_t = 0);
 constexpr sysex8_packet make_sysex8_end_packet(uint8_t stream_id, group_t = 0);
+
+//--------------------------------------------------------------------------
+
+constexpr mixed_data_set_header_packet  make_mixed_data_set_header_packet(uint4_t mds_id, group_t = 0);
+constexpr mixed_data_set_payload_packet make_mixed_data_set_payload_packet(uint4_t mds_id, group_t = 0);
 
 //--------------------------------------------------------------------------
 // constexpr implementations
@@ -201,6 +319,94 @@ constexpr std::optional<sysex8_packet_view> as_sysex8_packet_view(const universa
 {
     if (is_sysex8_packet(p))
         return sysex8_packet_view{ p };
+    else
+        return std::nullopt;
+}
+
+//--------------------------------------------------------------------------
+
+constexpr mixed_data_set_header_packet::mixed_data_set_header_packet()
+  : extended_data_message(extended_data_status::mixed_data_set_header)
+{
+}
+constexpr mixed_data_set_header_packet::mixed_data_set_header_packet(uint4_t mds_id, group_t group)
+{
+    data[0] =
+      0x50000000u | ((group & 0x0F) << 24) | ((extended_data_status::mixed_data_set_header | (mds_id & 0x0F)) << 16);
+}
+
+constexpr void mixed_data_set_header_packet::set_mds_id(uint4_t i)
+{
+    set_byte(1, (status() & 0xF0) | (i & 0x0F));
+}
+
+//--------------------------------------------------------------------------
+
+constexpr mixed_data_set_payload_packet::mixed_data_set_payload_packet()
+  : extended_data_message(extended_data_status::mixed_data_set_payload)
+{
+}
+constexpr mixed_data_set_payload_packet::mixed_data_set_payload_packet(uint4_t mds_id, group_t group)
+{
+    data[0] =
+      0x50000000u | ((group & 0x0F) << 24) | ((extended_data_status::mixed_data_set_payload | (mds_id & 0x0F)) << 16);
+}
+
+constexpr void mixed_data_set_payload_packet::set_mds_id(uint4_t i)
+{
+    set_byte(1, (status() & 0xF0) | (i & 0x0F));
+}
+
+constexpr void mixed_data_set_payload_packet::set_payload_byte(size_t b, uint8_t byte)
+{
+    assert(b < payload_size);
+    set_byte(2 + b, byte);
+}
+
+//--------------------------------------------------------------------------
+
+constexpr bool is_mixed_data_set_header_packet(const universal_packet& p)
+{
+    return is_extended_data_message(p) && ((p.status() & 0xF0) == extended_data_status::mixed_data_set_header);
+}
+
+constexpr bool is_mixed_data_set_payload_packet(const universal_packet& p)
+{
+    return is_extended_data_message(p) && ((p.status() & 0xF0) == extended_data_status::mixed_data_set_payload);
+}
+
+constexpr bool is_mixed_data_set_packet(const universal_packet& p)
+{
+    return is_mixed_data_set_header_packet(p) || is_mixed_data_set_payload_packet(p);
+}
+
+//--------------------------------------------------------------------------
+
+constexpr mixed_data_set_header_packet make_mixed_data_set_header_packet(uint4_t mds_id, group_t group)
+{
+    return mixed_data_set_header_packet{ mds_id, group };
+}
+constexpr mixed_data_set_payload_packet make_mixed_data_set_payload_packet(uint4_t mds_id, group_t group)
+{
+    return mixed_data_set_payload_packet{ mds_id, group };
+}
+
+//--------------------------------------------------------------------------
+
+constexpr std::optional<mixed_data_set_header_packet_view> as_mixed_data_set_header_packet_view(
+  const universal_packet& p)
+{
+    if (is_mixed_data_set_header_packet(p))
+        return mixed_data_set_header_packet_view{ p };
+    else
+        return std::nullopt;
+}
+
+constexpr std::optional<mixed_data_set_payload_packet_view> as_mixed_data_set_payload_packet_view(
+  const universal_packet& p)
+{
+    if (is_mixed_data_set_payload_packet(p))
+        return mixed_data_set_payload_packet_view{ p };
     else
         return std::nullopt;
 }

--- a/inc/midi/manufacturer.h
+++ b/inc/midi/manufacturer.h
@@ -36,6 +36,13 @@ using manufacturer_t = uint32_t;
 
 //--------------------------------------------------------------------------
 
+//! convert a manufacturer ID into its 16 bit representation
+constexpr uint16_t manufacturer_id_16bit(manufacturer_t);
+//! convert a 16 bit manufacturer ID into manufacturer_t representation
+constexpr manufacturer_t manufacturer_from_16bit_id(uint16_t);
+
+//--------------------------------------------------------------------------
+
 namespace manufacturer {
     constexpr manufacturer_t sequential_circuits = 0x010000;
     constexpr manufacturer_t moog                = 0x040000;
@@ -118,6 +125,32 @@ namespace manufacturer {
     constexpr manufacturer_t bome               = 0x002132;
     constexpr manufacturer_t touchkeys          = 0x002136;
 } // namespace manufacturer
+
+//----------------------------------------------- inline implementations
+
+constexpr uint16_t manufacturer_id_16bit(manufacturer_t m)
+{
+    if (m & 0x00FFFF)
+    {
+        // three byte manufacturer ID, high bit set
+        return uint16_t(0x8000u | (m & 0x7F00) | (m & 0x7F));
+    }
+
+    // one byte manufacturer ID
+    return uint16_t((m >> 16) & 0x7F);
+}
+
+constexpr manufacturer_t manufacturer_from_16bit_id(uint16_t id)
+{
+    if (id & 0x8000)
+    {
+        // three byte manufacturer ID
+        return manufacturer_t(id & 0x7F7F);
+    }
+
+    // one byte manufacturer ID
+    return manufacturer_t(id & 0x7F) << 16;
+}
 
 //--------------------------------------------------------------------------
 

--- a/inc/midi/mixed_data_set.h
+++ b/inc/midi/mixed_data_set.h
@@ -1,0 +1,277 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#pragma once
+
+//--------------------------------------------------------------------------
+
+#include <midi/extended_data_message.h>
+#include <midi/manufacturer.h>
+#include <midi/sysex.h>
+#include <midi/types.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+//--------------------------------------------------------------------------
+
+namespace midi {
+
+//--------------------------------------------------------------------------
+
+//! convert a manufacturer ID into its 16 bit Mixed Data Set representation
+constexpr uint16_t mixed_data_set_manufacturer_id(manufacturer_t);
+//! convert a 16 bit Mixed Data Set manufacturer ID into manufacturer_t representation
+constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t);
+
+//--------------------------------------------------------------------------
+//! MIDI Mixed Data Set
+struct mixed_data_set
+{
+    using data_type = sysex::data_type; //!< same data type (and allocator configuration) as sysex
+
+    manufacturer_t manufacturerID{ 0 }; //!< manufacturer ID, \see midi::manufacturer
+    uint16_t       deviceID{ 0 };       //!< device ID, 0xFFFF means 'all call'
+    uint16_t       subID1{ 0 };         //!< sub ID #1
+    uint16_t       subID2{ 0 };         //!< sub ID #2
+    data_type      data;                //!< Mixed Data Set payload data
+
+    mixed_data_set() = default;
+
+    /*! \param manufacturer manufacturer */
+    explicit mixed_data_set(manufacturer_t manufacturer NIMIDI2_PMR_SYSEX_DATA_ARG)
+      : manufacturerID(manufacturer)
+      , data(NIMIDI2_PMR_SYSEX_DATA_DATA_INITIALIZER)
+    {
+    }
+
+    /*! \param manufacturer manufacturer
+        \param device_id device ID, 0xFFFF means 'all call'
+        \param sub_id_1 sub ID #1
+        \param sub_id_2 sub ID #2
+    */
+    mixed_data_set(manufacturer_t    manufacturer,
+                   uint16_t          device_id,
+                   uint16_t          sub_id_1,
+                   uint16_t sub_id_2 NIMIDI2_PMR_SYSEX_DATA_ARG)
+      : manufacturerID(manufacturer)
+      , deviceID(device_id)
+      , subID1(sub_id_1)
+      , subID2(sub_id_2)
+      , data(NIMIDI2_PMR_SYSEX_DATA_DATA_INITIALIZER)
+    {
+    }
+
+    /*! \param manufacturer manufacturer
+        \param device_id device ID, 0xFFFF means 'all call'
+        \param sub_id_1 sub ID #1
+        \param sub_id_2 sub ID #2
+        \param d payload data
+    */
+    mixed_data_set(manufacturer_t manufacturer,
+                   uint16_t       device_id,
+                   uint16_t       sub_id_1,
+                   uint16_t       sub_id_2,
+                   data_type d    NIMIDI2_PMR_SYSEX_DATA_ARG)
+      : manufacturerID(manufacturer)
+      , deviceID(device_id)
+      , subID1(sub_id_1)
+      , subID2(sub_id_2)
+      , data(std::move(d) NIMIDI2_PMR_SYSEX_DATA_DATA_INITIALIZER_SUFFIX)
+    {
+    }
+
+    /*! \param manufacturer manufacturer
+        \param device_id device ID, 0xFFFF means 'all call'
+        \param sub_id_1 sub ID #1
+        \param sub_id_2 sub ID #2
+        \param d payload data
+    */
+    mixed_data_set(manufacturer_t                   manufacturer,
+                   uint16_t                         device_id,
+                   uint16_t                         sub_id_1,
+                   uint16_t                         sub_id_2,
+                   std::initializer_list<uint8_t> d NIMIDI2_PMR_SYSEX_DATA_ARG)
+      : manufacturerID(manufacturer)
+      , deviceID(device_id)
+      , subID1(sub_id_1)
+      , subID2(sub_id_2)
+      , data(d.begin(), d.end() NIMIDI2_PMR_SYSEX_DATA_DATA_INITIALIZER_SUFFIX)
+    {
+    }
+
+#if NIMIDI2_PMR_SYSEX_DATA
+    mixed_data_set(manufacturer_t              manufacturer,
+                   uint16_t                    device_id,
+                   uint16_t                    sub_id_1,
+                   uint16_t                    sub_id_2,
+                   const std::vector<uint8_t>& d,
+                   std::pmr::memory_resource*  mr = std::pmr::get_default_resource())
+      : manufacturerID(manufacturer)
+      , deviceID(device_id)
+      , subID1(sub_id_1)
+      , subID2(sub_id_2)
+      , data(d.begin(), d.end(), mr)
+    {
+    }
+#endif
+
+    mixed_data_set(const mixed_data_set&) = default;
+    mixed_data_set(mixed_data_set&&)      = default;
+
+    ~mixed_data_set() = default;
+
+    mixed_data_set& operator=(const mixed_data_set&) = default;
+    mixed_data_set& operator=(mixed_data_set&&)      = default;
+
+    bool operator==(const mixed_data_set&) const;
+    bool operator!=(const mixed_data_set&) const;
+
+    void clear();
+};
+
+//--------------------------------------------------------------------------
+
+template<typename Sender>
+void send_mixed_data_set(const mixed_data_set&, uint4_t mds_id, group_t, Sender&&);
+
+std::vector<extended_data_message> as_mixed_data_set_packets(const mixed_data_set&, uint4_t mds_id, group_t = 0);
+
+//----------------------------------------------- inline implementations
+
+constexpr uint16_t mixed_data_set_manufacturer_id(manufacturer_t m)
+{
+    if (m & 0x00FFFF)
+    {
+        // three byte manufacturer ID, high bit set
+        return uint16_t(0x8000u | (m & 0x7F00) | (m & 0x7F));
+    }
+
+    // one byte manufacturer ID
+    return uint16_t((m >> 16) & 0x7F);
+}
+
+constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t id)
+{
+    if (id & 0x8000)
+    {
+        // three byte manufacturer ID
+        return manufacturer_t(id & 0x7F7F);
+    }
+
+    // one byte manufacturer ID
+    return manufacturer_t(id & 0x7F) << 16;
+}
+
+//--------------------------------------------------------------------------
+
+inline bool mixed_data_set::operator==(const mixed_data_set& other) const
+{
+    return (manufacturerID == other.manufacturerID) && (deviceID == other.deviceID) && (subID1 == other.subID1) &&
+           (subID2 == other.subID2) && (data == other.data);
+}
+
+inline bool mixed_data_set::operator!=(const mixed_data_set& other) const
+{
+    return !operator==(other);
+}
+
+inline void mixed_data_set::clear()
+{
+    manufacturerID = 0;
+    deviceID       = 0;
+    subID1         = 0;
+    subID2         = 0;
+    data.clear();
+}
+
+//--------------------------------------------------------------------------
+
+template<typename Sender>
+void send_mixed_data_set(const mixed_data_set& mds, uint4_t mds_id, group_t group, Sender&& sender)
+{
+    constexpr size_t payload_bytes_per_packet = mixed_data_set_payload_packet::payload_size;
+
+    // the valid bytes in a chunk (16 header bytes plus 16 for every full payload packet)
+    // are limited to 65535, resulting in at most 4094 payload packets per chunk
+    constexpr size_t max_packets_per_chunk = 4094;
+    constexpr size_t max_chunk_data_size   = max_packets_per_chunk * payload_bytes_per_packet;
+
+    const auto manufacturer = mixed_data_set_manufacturer_id(mds.manufacturerID);
+
+    const size_t   total_data_size = mds.data.size();
+    const uint16_t nr_of_chunks =
+      (total_data_size == 0) ? 1 : uint16_t((total_data_size + max_chunk_data_size - 1) / max_chunk_data_size);
+
+    size_t offset = 0;
+    for (uint16_t chunk_nr = 1; chunk_nr <= nr_of_chunks; ++chunk_nr)
+    {
+        const size_t chunk_data_size = std::min(total_data_size - offset, max_chunk_data_size);
+        const size_t nr_of_packets   = (chunk_data_size + payload_bytes_per_packet - 1) / payload_bytes_per_packet;
+
+        auto header = make_mixed_data_set_header_packet(mds_id, group);
+        header.set_valid_bytes_in_chunk(uint16_t(16u + 2u * nr_of_packets + chunk_data_size));
+        header.set_nr_of_chunks(nr_of_chunks);
+        header.set_chunk_nr(chunk_nr);
+        header.set_manufacturer_id(manufacturer);
+        header.set_device_id(mds.deviceID);
+        header.set_sub_id_1(mds.subID1);
+        header.set_sub_id_2(mds.subID2);
+        sender(header);
+
+        for (size_t packet_nr = 0; packet_nr < nr_of_packets; ++packet_nr)
+        {
+            auto p = make_mixed_data_set_payload_packet(mds_id, group);
+
+            const size_t packet_offset = packet_nr * payload_bytes_per_packet;
+            const size_t payload_bytes = std::min(payload_bytes_per_packet, chunk_data_size - packet_offset);
+            for (size_t b = 0; b < payload_bytes; ++b)
+            {
+                p.set_payload_byte(b, mds.data[offset + packet_offset + b]);
+            }
+            sender(p);
+        }
+
+        offset += chunk_data_size;
+    }
+}
+
+//--------------------------------------------------------------------------
+
+inline std::vector<extended_data_message> as_mixed_data_set_packets(const mixed_data_set& mds,
+                                                                    uint4_t               mds_id,
+                                                                    group_t               group)
+{
+    std::vector<extended_data_message> result;
+    result.reserve(mds.data.size() / mixed_data_set_payload_packet::payload_size + 2);
+
+    send_mixed_data_set(mds, mds_id, group, [&](const extended_data_message& p) { result.push_back(p); });
+
+    return result;
+}
+
+//--------------------------------------------------------------------------
+
+} // namespace midi
+
+//--------------------------------------------------------------------------

--- a/inc/midi/mixed_data_set.h
+++ b/inc/midi/mixed_data_set.h
@@ -39,12 +39,6 @@ namespace midi {
 
 //--------------------------------------------------------------------------
 
-//! convert a manufacturer ID into its 16 bit Mixed Data Set representation
-constexpr uint16_t mixed_data_set_manufacturer_id(manufacturer_t);
-//! convert a 16 bit Mixed Data Set manufacturer ID into manufacturer_t representation
-constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t);
-
-//--------------------------------------------------------------------------
 //! MIDI Mixed Data Set
 struct mixed_data_set
 {
@@ -159,32 +153,6 @@ std::vector<extended_data_message> as_mixed_data_set_packets(const mixed_data_se
 
 //----------------------------------------------- inline implementations
 
-constexpr uint16_t mixed_data_set_manufacturer_id(manufacturer_t m)
-{
-    if (m & 0x00FFFF)
-    {
-        // three byte manufacturer ID, high bit set
-        return uint16_t(0x8000u | (m & 0x7F00) | (m & 0x7F));
-    }
-
-    // one byte manufacturer ID
-    return uint16_t((m >> 16) & 0x7F);
-}
-
-constexpr manufacturer_t manufacturer_from_mixed_data_set_id(uint16_t id)
-{
-    if (id & 0x8000)
-    {
-        // three byte manufacturer ID
-        return manufacturer_t(id & 0x7F7F);
-    }
-
-    // one byte manufacturer ID
-    return manufacturer_t(id & 0x7F) << 16;
-}
-
-//--------------------------------------------------------------------------
-
 inline bool mixed_data_set::operator==(const mixed_data_set& other) const
 {
     return (manufacturerID == other.manufacturerID) && (deviceID == other.deviceID) && (subID1 == other.subID1) &&
@@ -217,7 +185,7 @@ void send_mixed_data_set(const mixed_data_set& mds, uint4_t mds_id, group_t grou
     constexpr size_t max_packets_per_chunk = 4094;
     constexpr size_t max_chunk_data_size   = max_packets_per_chunk * payload_bytes_per_packet;
 
-    const auto manufacturer = mixed_data_set_manufacturer_id(mds.manufacturerID);
+    const auto manufacturer = manufacturer_id_16bit(mds.manufacturerID);
 
     const size_t   total_data_size = mds.data.size();
     const uint16_t nr_of_chunks =

--- a/inc/midi/mixed_data_set_collector.h
+++ b/inc/midi/mixed_data_set_collector.h
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#pragma once
+
+//--------------------------------------------------------------------------
+
+#include <midi/extended_data_message.h>
+#include <midi/mixed_data_set.h>
+#include <midi/universal_packet.h>
+
+#include <array>
+#include <functional>
+#include <utility>
+
+//--------------------------------------------------------------------------
+
+namespace midi {
+
+//--------------------------------------------------------------------------
+
+class mixed_data_set_collector
+{
+  public:
+    using callback = std::function<void(const mixed_data_set&, uint4_t mds_id)>;
+
+    explicit mixed_data_set_collector(callback);
+
+    void set_callback(callback);
+    void set_max_data_size(size_t); //!< limit maximum size of accepted mixed data set data
+
+    void feed(const universal_packet&);
+    void reset();
+
+  private:
+    //! collection state, one per mds_id
+    //! (up to 16 mixed data sets can be transmitted simultaneously per group)
+    struct assembly
+    {
+        mixed_data_set data;
+        uint16_t       nr_of_chunks{ 0 }; //!< declared by most recent chunk header, 0 means unknown
+        uint16_t       chunks_collected{ 0 };
+        size_t         chunk_bytes_left{ 0 }; //!< payload data bytes still expected in current chunk
+        bool           collecting{ false };
+
+        void reset();
+    };
+
+    void process_header(const mixed_data_set_header_packet_view&);
+    void process_payload(const mixed_data_set_payload_packet_view&);
+    void complete_chunk(assembly&, uint4_t mds_id);
+
+    std::array<assembly, 16> m_assemblies;
+    size_t                   m_max_data_size{ 0 };
+    callback                 m_cb;
+};
+
+//--------------------------------------------------------------------------
+
+inline mixed_data_set_collector::mixed_data_set_collector(callback cb)
+  : m_cb(std::move(cb))
+{
+}
+inline void mixed_data_set_collector::set_callback(callback cb)
+{
+    m_cb = std::move(cb);
+}
+
+//--------------------------------------------------------------------------
+
+} // namespace midi
+
+//--------------------------------------------------------------------------

--- a/src/mixed_data_set_collector.cpp
+++ b/src/mixed_data_set_collector.cpp
@@ -89,7 +89,7 @@ void mixed_data_set_collector::process_header(const mixed_data_set_header_packet
         // start of a new mixed data set
         a.reset();
         a.collecting          = true;
-        a.data.manufacturerID = manufacturer_from_mixed_data_set_id(h.manufacturer_id());
+        a.data.manufacturerID = manufacturer_from_16bit_id(h.manufacturer_id());
         a.data.deviceID       = h.device_id();
         a.data.subID1         = h.sub_id_1();
         a.data.subID2         = h.sub_id_2();

--- a/src/mixed_data_set_collector.cpp
+++ b/src/mixed_data_set_collector.cpp
@@ -1,0 +1,192 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include <midi/mixed_data_set_collector.h>
+
+#include <algorithm>
+
+//--------------------------------------------------------------------------
+
+namespace midi {
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::set_max_data_size(size_t s)
+{
+    m_max_data_size = s;
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::feed(const universal_packet& p)
+{
+    if (is_mixed_data_set_header_packet(p))
+    {
+        process_header(mixed_data_set_header_packet_view{ p });
+    }
+    else if (is_mixed_data_set_payload_packet(p))
+    {
+        process_payload(mixed_data_set_payload_packet_view{ p });
+    }
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::reset()
+{
+    for (auto& a : m_assemblies)
+    {
+        a.reset();
+    }
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::assembly::reset()
+{
+    data.clear();
+    nr_of_chunks     = 0;
+    chunks_collected = 0;
+    chunk_bytes_left = 0;
+    collecting       = false;
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::process_header(const mixed_data_set_header_packet_view& h)
+{
+    auto& a = m_assemblies[h.mds_id()];
+
+    const auto chunk_nr = h.chunk_nr();
+    if (chunk_nr == 0)
+    {
+        // mixed data set aborted by sender
+        a.reset();
+        return;
+    }
+
+    if (chunk_nr == 1)
+    {
+        // start of a new mixed data set
+        a.reset();
+        a.collecting          = true;
+        a.data.manufacturerID = manufacturer_from_mixed_data_set_id(h.manufacturer_id());
+        a.data.deviceID       = h.device_id();
+        a.data.subID1         = h.sub_id_1();
+        a.data.subID2         = h.sub_id_2();
+    }
+    else if (!a.collecting || (chunk_nr != a.chunks_collected + 1))
+    {
+        // invalid chunk sequence, reset
+        a.reset();
+        return;
+    }
+
+    a.nr_of_chunks = h.nr_of_chunks();
+    if (a.nr_of_chunks && (chunk_nr > a.nr_of_chunks))
+    {
+        // invalid chunk header, reset
+        a.reset();
+        return;
+    }
+
+    // derive the number of chunk data bytes from the valid bytes in chunk
+    // (16 header bytes plus two status bytes per payload packet)
+    const auto valid_bytes = h.valid_bytes_in_chunk();
+    if (valid_bytes < 16)
+    {
+        // invalid chunk header, reset
+        a.reset();
+        return;
+    }
+    const size_t valid_payload_bytes = valid_bytes - 16u;
+    const size_t nr_of_packets       = (valid_payload_bytes + 15u) / 16u;
+    if (valid_payload_bytes < 2 * nr_of_packets)
+    {
+        // invalid chunk header, reset
+        a.reset();
+        return;
+    }
+    a.chunk_bytes_left = valid_payload_bytes - 2 * nr_of_packets;
+
+    if (m_max_data_size && (a.data.data.size() + a.chunk_bytes_left > m_max_data_size))
+    {
+        // data size exceeds m_max_data_size, wait for start of new mixed data set
+        a.reset();
+        return;
+    }
+    a.data.data.reserve(a.data.data.size() + a.chunk_bytes_left);
+
+    if (a.chunk_bytes_left == 0)
+    {
+        // header only chunk
+        complete_chunk(a, h.mds_id());
+    }
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::process_payload(const mixed_data_set_payload_packet_view& p)
+{
+    auto& a = m_assemblies[p.mds_id()];
+
+    if (!a.collecting || (a.chunk_bytes_left == 0))
+    {
+        // unexpected payload packet, ignore
+        return;
+    }
+
+    const auto numBytes = std::min(mixed_data_set_payload_packet::payload_size, a.chunk_bytes_left);
+    for (size_t b = 0; b < numBytes; ++b)
+    {
+        a.data.data.push_back(p.payload_byte(b));
+    }
+    a.chunk_bytes_left -= numBytes;
+
+    if (a.chunk_bytes_left == 0)
+    {
+        complete_chunk(a, p.mds_id());
+    }
+}
+
+//--------------------------------------------------------------------------
+
+void mixed_data_set_collector::complete_chunk(assembly& a, uint4_t mds_id)
+{
+    ++a.chunks_collected;
+
+    if (a.nr_of_chunks == a.chunks_collected)
+    {
+        // final chunk collected, mixed data set is complete
+        if (m_cb)
+        {
+            m_cb(a.data, mds_id);
+        }
+        a.reset();
+    }
+}
+
+//--------------------------------------------------------------------------
+
+} // namespace midi
+
+//--------------------------------------------------------------------------

--- a/tests/extended_data_message_tests.cpp
+++ b/tests/extended_data_message_tests.cpp
@@ -702,3 +702,207 @@ TEST(extended_data_message, make_sysex8_end_packet)
 }
 
 //-----------------------------------------------
+
+TEST(extended_data_message, mixed_data_set_header_packet_constructors)
+{
+    using namespace midi;
+
+    {
+        constexpr midi::mixed_data_set_header_packet m;
+
+        EXPECT_EQ(packet_type::extended_data, m.type());
+        EXPECT_EQ(0u, m.group());
+        EXPECT_EQ(extended_data_status::mixed_data_set_header, m.status());
+        EXPECT_EQ(0u, m.mds_id());
+
+        EXPECT_EQ(0x50800000u, m.data[0]);
+        EXPECT_EQ(0u, m.data[1]);
+        EXPECT_EQ(0u, m.data[2]);
+        EXPECT_EQ(0u, m.data[3]);
+
+        EXPECT_TRUE(is_extended_data_message(m));
+        EXPECT_TRUE(is_mixed_data_set_header_packet(m));
+        EXPECT_TRUE(is_mixed_data_set_packet(m));
+        EXPECT_FALSE(is_mixed_data_set_payload_packet(m));
+        EXPECT_FALSE(is_sysex8_packet(m));
+    }
+
+    {
+        constexpr midi::mixed_data_set_header_packet m{ 0xA, 0xC };
+
+        EXPECT_EQ(packet_type::extended_data, m.type());
+        EXPECT_EQ(12u, m.group());
+        EXPECT_EQ(extended_data_status::mixed_data_set_header | 0xA, m.status());
+        EXPECT_EQ(0xAu, m.mds_id());
+
+        EXPECT_EQ(0x5C8A0000u, m.data[0]);
+
+        EXPECT_TRUE(is_mixed_data_set_header_packet(m));
+    }
+}
+
+//-----------------------------------------------
+
+TEST(extended_data_message, mixed_data_set_header_packet_fields)
+{
+    using namespace midi;
+
+    auto m = make_mixed_data_set_header_packet(0x3, 0x9);
+    EXPECT_EQ(0x3u, m.mds_id());
+    EXPECT_EQ(0x9u, m.group());
+
+    m.set_valid_bytes_in_chunk(0x1234);
+    m.set_nr_of_chunks(0x5678);
+    m.set_chunk_nr(0x9ABC);
+    m.set_manufacturer_id(0xA109);
+    m.set_device_id(0xFFFF);
+    m.set_sub_id_1(0x0102);
+    m.set_sub_id_2(0x0304);
+
+    EXPECT_EQ(0x1234u, m.valid_bytes_in_chunk());
+    EXPECT_EQ(0x5678u, m.nr_of_chunks());
+    EXPECT_EQ(0x9ABCu, m.chunk_nr());
+    EXPECT_EQ(0xA109u, m.manufacturer_id());
+    EXPECT_EQ(0xFFFFu, m.device_id());
+    EXPECT_EQ(0x0102u, m.sub_id_1());
+    EXPECT_EQ(0x0304u, m.sub_id_2());
+
+    EXPECT_EQ(0x59831234u, m.data[0]);
+    EXPECT_EQ(0x56789ABCu, m.data[1]);
+    EXPECT_EQ(0xA109FFFFu, m.data[2]);
+    EXPECT_EQ(0x01020304u, m.data[3]);
+
+    m.set_mds_id(0xF);
+    EXPECT_EQ(0xFu, m.mds_id());
+    EXPECT_EQ(extended_data_status::mixed_data_set_header | 0xF, m.status());
+}
+
+//-----------------------------------------------
+
+TEST(extended_data_message, mixed_data_set_payload_packet_constructors)
+{
+    using namespace midi;
+
+    {
+        constexpr midi::mixed_data_set_payload_packet m;
+
+        EXPECT_EQ(packet_type::extended_data, m.type());
+        EXPECT_EQ(0u, m.group());
+        EXPECT_EQ(extended_data_status::mixed_data_set_payload, m.status());
+        EXPECT_EQ(0u, m.mds_id());
+
+        EXPECT_EQ(0x50900000u, m.data[0]);
+
+        EXPECT_TRUE(is_extended_data_message(m));
+        EXPECT_TRUE(is_mixed_data_set_payload_packet(m));
+        EXPECT_TRUE(is_mixed_data_set_packet(m));
+        EXPECT_FALSE(is_mixed_data_set_header_packet(m));
+        EXPECT_FALSE(is_sysex8_packet(m));
+    }
+
+    {
+        constexpr midi::mixed_data_set_payload_packet m{ 0x5, 0x3 };
+
+        EXPECT_EQ(packet_type::extended_data, m.type());
+        EXPECT_EQ(3u, m.group());
+        EXPECT_EQ(extended_data_status::mixed_data_set_payload | 0x5, m.status());
+        EXPECT_EQ(0x5u, m.mds_id());
+
+        EXPECT_EQ(0x53950000u, m.data[0]);
+    }
+}
+
+//-----------------------------------------------
+
+TEST(extended_data_message, mixed_data_set_payload_packet_payload)
+{
+    using namespace midi;
+
+    auto m = make_mixed_data_set_payload_packet(0x5, 0x3);
+
+    for (size_t b = 0; b < mixed_data_set_payload_packet::payload_size; ++b)
+    {
+        m.set_payload_byte(b, uint8_t(b + 1));
+    }
+
+    EXPECT_EQ(0x53950102u, m.data[0]);
+    EXPECT_EQ(0x03040506u, m.data[1]);
+    EXPECT_EQ(0x0708090Au, m.data[2]);
+    EXPECT_EQ(0x0B0C0D0Eu, m.data[3]);
+
+    for (size_t b = 0; b < mixed_data_set_payload_packet::payload_size; ++b)
+    {
+        EXPECT_EQ(b + 1, m.payload_byte(b));
+    }
+}
+
+//-----------------------------------------------
+
+TEST(extended_data_message, is_mixed_data_set_packet)
+{
+    using namespace midi;
+
+    EXPECT_TRUE(is_mixed_data_set_header_packet(universal_packet{ 0x50800000, 0, 0, 0 }));
+    EXPECT_TRUE(is_mixed_data_set_header_packet(universal_packet{ 0x5F8F1234, 1, 2, 3 }));
+    EXPECT_TRUE(is_mixed_data_set_payload_packet(universal_packet{ 0x50900000, 0, 0, 0 }));
+    EXPECT_TRUE(is_mixed_data_set_payload_packet(universal_packet{ 0x5F9F1234, 1, 2, 3 }));
+
+    EXPECT_FALSE(is_mixed_data_set_header_packet(universal_packet{ 0x50900000, 0, 0, 0 }));
+    EXPECT_FALSE(is_mixed_data_set_payload_packet(universal_packet{ 0x50800000, 0, 0, 0 }));
+
+    // sysex8 packets are not mixed data set packets
+    EXPECT_FALSE(is_mixed_data_set_packet(universal_packet{ 0x51010000, 0, 1, 2 }));
+    EXPECT_FALSE(is_mixed_data_set_packet(universal_packet{ 0x53340000, 0, 1, 2 }));
+
+    // other packet types are not mixed data set packets
+    EXPECT_FALSE(is_mixed_data_set_packet(universal_packet{ 0x21903C7F }));
+    EXPECT_FALSE(is_mixed_data_set_packet(universal_packet{ 0xD0100000, 0, 0, 0 }));
+}
+
+//-----------------------------------------------
+
+TEST(extended_data_message, mixed_data_set_packet_views)
+{
+    using namespace midi;
+
+    {
+        constexpr universal_packet p{ 0x59831234, 0x56789ABC, 0xA109FFFF, 0x01020304 };
+
+        auto v = as_mixed_data_set_header_packet_view(p);
+        ASSERT_TRUE(v.has_value());
+        EXPECT_EQ(0x9u, v->group());
+        EXPECT_EQ(0x3u, v->mds_id());
+        EXPECT_EQ(0x1234u, v->valid_bytes_in_chunk());
+        EXPECT_EQ(0x5678u, v->nr_of_chunks());
+        EXPECT_EQ(0x9ABCu, v->chunk_nr());
+        EXPECT_EQ(0xA109u, v->manufacturer_id());
+        EXPECT_EQ(0xFFFFu, v->device_id());
+        EXPECT_EQ(0x0102u, v->sub_id_1());
+        EXPECT_EQ(0x0304u, v->sub_id_2());
+
+        EXPECT_FALSE(as_mixed_data_set_payload_packet_view(p).has_value());
+    }
+
+    {
+        constexpr universal_packet p{ 0x53950102, 0x03040506, 0x0708090A, 0x0B0C0D0E };
+
+        auto v = as_mixed_data_set_payload_packet_view(p);
+        ASSERT_TRUE(v.has_value());
+        EXPECT_EQ(0x3u, v->group());
+        EXPECT_EQ(0x5u, v->mds_id());
+        for (size_t b = 0; b < mixed_data_set_payload_packet::payload_size; ++b)
+        {
+            EXPECT_EQ(b + 1, v->payload_byte(b));
+        }
+
+        EXPECT_FALSE(as_mixed_data_set_header_packet_view(p).has_value());
+    }
+
+    {
+        constexpr universal_packet p{ 0x21903C7F };
+        EXPECT_FALSE(as_mixed_data_set_header_packet_view(p).has_value());
+        EXPECT_FALSE(as_mixed_data_set_payload_packet_view(p).has_value());
+    }
+}
+
+//-----------------------------------------------

--- a/tests/mixed_data_set_collector_tests.cpp
+++ b/tests/mixed_data_set_collector_tests.cpp
@@ -1,0 +1,524 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include <gtest/gtest.h>
+
+#include <midi/mixed_data_set_collector.h>
+
+#include <midi/extended_data_message.h>
+#include <midi/manufacturer.h>
+
+#include "mixed_data_set_test_data.h"
+
+#include <string>
+#include <vector>
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, constructor)
+{
+    using namespace midi;
+
+    auto c = midi::mixed_data_set_collector({});
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, set_callback)
+{
+    using namespace midi;
+
+    auto c = midi::mixed_data_set_collector({});
+
+    bool called = false;
+    auto f      = [&called](const mixed_data_set&, uint4_t) { called = true; };
+    c.set_callback(f);
+
+    // header only chunk (1 of 1) completes a mixed data set
+    c.feed({ 0x50800010, 0x00010001, 0x007E0000, 0 });
+    EXPECT_TRUE(called);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, regular_collect)
+{
+    using namespace midi;
+
+    {
+        for (const auto& entry : mixed_data_set_test_cases)
+        {
+            bool output_generated = false;
+            auto cb               = [&](const midi::mixed_data_set& m, uint4_t mds_id) {
+                output_generated = true;
+                EXPECT_EQ(mds_id, entry.mds_id) << entry.description;
+                EXPECT_EQ(m, entry.mds) << entry.description;
+            };
+
+            auto c = midi::mixed_data_set_collector{ cb };
+            for (const auto& p : entry.packets)
+            {
+                c.feed(p);
+            }
+
+            EXPECT_TRUE(output_generated) << entry.description;
+        }
+    }
+
+    {
+        bool     output_generated = false;
+        unsigned curEntry         = 0;
+        auto     cb               = [&](const midi::mixed_data_set& m, uint4_t mds_id) {
+            output_generated = true;
+            EXPECT_EQ(mds_id, mixed_data_set_test_cases[curEntry].mds_id)
+              << mixed_data_set_test_cases[curEntry].description;
+            EXPECT_EQ(m, mixed_data_set_test_cases[curEntry].mds) << mixed_data_set_test_cases[curEntry].description;
+        };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+
+        for (const auto& entry : mixed_data_set_test_cases)
+        {
+            for (const auto& p : entry.packets)
+            {
+                c.feed(p);
+            }
+
+            EXPECT_TRUE(output_generated) << entry.description;
+            output_generated = false;
+            ++curEntry;
+        }
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, interleaved_mds_ids)
+{
+    using namespace midi;
+
+    // two mixed data sets with different mds ids can be collected simultaneously
+    const auto& a = mixed_data_set_test_cases[3]; // "two chunks", mds_id 0x7
+    const auto& b = mixed_data_set_test_cases[4]; // "unknown number of chunks", mds_id 0x1
+
+    unsigned deliveries = 0;
+    auto     cb         = [&](const midi::mixed_data_set& m, uint4_t mds_id) {
+        ++deliveries;
+        if (mds_id == a.mds_id)
+        {
+            EXPECT_EQ(m, a.mds);
+        }
+        else
+        {
+            EXPECT_EQ(mds_id, b.mds_id);
+            EXPECT_EQ(m, b.mds);
+        }
+    };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    ASSERT_EQ(a.packets.size(), b.packets.size());
+    for (size_t i = 0; i < a.packets.size(); ++i)
+    {
+        c.feed(a.packets[i]);
+        c.feed(b.packets[i]);
+    }
+
+    EXPECT_EQ(2u, deliveries);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, abort)
+{
+    using namespace midi;
+
+    bool output_generated = false;
+    auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // first chunk of two
+    c.feed({ 0x50870020, 0x00020001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD });
+    EXPECT_FALSE(output_generated);
+
+    // abort: chunk_nr == 0
+    c.feed({ 0x50870010, 0x00020000, 0x007F0001, 0x00020003 });
+    EXPECT_FALSE(output_generated);
+
+    // second chunk of the aborted set is ignored
+    c.feed({ 0x50870015, 0x00020002, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+    EXPECT_FALSE(output_generated);
+
+    // a new mixed data set with the same mds id is collected
+    const auto& entry = mixed_data_set_test_cases[3];
+    for (const auto& p : entry.packets)
+    {
+        c.feed(p);
+    }
+    EXPECT_TRUE(output_generated);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, exceptional_collect)
+{
+    using namespace midi;
+
+    // payload packet without header is ignored
+    {
+        auto cb = [&](const midi::mixed_data_set&, uint4_t) { GTEST_FAIL(); };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+        c.feed({ 0x50901122, 0x33445500, 0, 0 });
+    }
+
+    // chunk 2 without chunk 1 is ignored
+    {
+        auto cb = [&](const midi::mixed_data_set&, uint4_t) { GTEST_FAIL(); };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+        c.feed({ 0x50870015, 0x00020002, 0x007F0001, 0x00020003 });
+        c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+    }
+
+    // out of order chunk resets the collection
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+
+        // chunk 1 of 3
+        c.feed({ 0x50870020, 0x00030001, 0x007F0001, 0x00020003 });
+        c.feed({ 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD });
+
+        // chunk 3 of 3 out of order
+        c.feed({ 0x50870015, 0x00030003, 0x007F0001, 0x00020003 });
+        c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+
+        EXPECT_FALSE(output_generated);
+    }
+
+    // invalid valid_bytes_in_chunk resets the collection
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+
+        // valid bytes < 16 is invalid
+        c.feed({ 0x5087000F, 0x00010001, 0x007F0001, 0x00020003 });
+        EXPECT_FALSE(output_generated);
+
+        // regular message on same mds id is collected afterwards
+        const auto& entry = mixed_data_set_test_cases[3];
+        for (const auto& p : entry.packets)
+        {
+            c.feed(p);
+        }
+        EXPECT_TRUE(output_generated);
+    }
+
+    // non mixed data set packets are ignored
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set& m, uint4_t) {
+            output_generated = true;
+            EXPECT_EQ(m, mixed_data_set_test_cases[1].mds);
+        };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+
+        const auto& entry = mixed_data_set_test_cases[1];
+        c.feed(entry.packets[0]);
+        c.feed({ 0x51010000, 0, 1, 2 });        // sysex8 packet
+        c.feed(universal_packet{ 0x21903C7F }); // midi1 note on
+        c.feed(entry.packets[1]);
+
+        EXPECT_TRUE(output_generated);
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, limited_data_size_collect)
+{
+    using namespace midi;
+
+    // message within limit is collected
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set& m, uint4_t) {
+            output_generated = true;
+            EXPECT_EQ(m.data.size(), 20u);
+        };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+        c.set_max_data_size(20);
+
+        for (const auto& p : mixed_data_set_test_cases[2].packets)
+        {
+            c.feed(p);
+        }
+
+        EXPECT_TRUE(output_generated);
+    }
+
+    // message exceeding limit is discarded
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+        c.set_max_data_size(19);
+
+        for (const auto& p : mixed_data_set_test_cases[2].packets)
+        {
+            c.feed(p);
+        }
+
+        EXPECT_FALSE(output_generated);
+    }
+
+    // limit applies to accumulated chunks
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+        c.set_max_data_size(15);
+
+        // "two chunks" test case carries 14 + 3 bytes
+        for (const auto& p : mixed_data_set_test_cases[3].packets)
+        {
+            c.feed(p);
+        }
+
+        EXPECT_FALSE(output_generated);
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, roundtrip)
+{
+    using namespace midi;
+
+    for (const auto& entry : mixed_data_set_test_cases)
+    {
+        bool output_generated = false;
+        auto cb               = [&](const midi::mixed_data_set& m, uint4_t mds_id) {
+            output_generated = true;
+            EXPECT_EQ(mds_id, entry.mds_id) << entry.description;
+            EXPECT_EQ(m, entry.mds) << entry.description;
+        };
+
+        auto c = midi::mixed_data_set_collector{ cb };
+
+        for (const auto& p : as_mixed_data_set_packets(entry.mds, entry.mds_id))
+        {
+            c.feed(p);
+        }
+
+        EXPECT_TRUE(output_generated) << entry.description;
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, reset)
+{
+    using namespace midi;
+
+    bool output_generated = false;
+    auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // first chunk of two
+    c.feed({ 0x50870020, 0x00020001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD });
+
+    c.reset();
+
+    // second chunk of the reset collection is ignored
+    c.feed({ 0x50870015, 0x00020002, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+
+    EXPECT_FALSE(output_generated);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, restart_without_abort)
+{
+    using namespace midi;
+
+    // a chunk 1 header while a collection is in progress starts a new mixed data set,
+    // discarding the incomplete one
+    unsigned deliveries = 0;
+    auto     cb         = [&](const midi::mixed_data_set& m, uint4_t) {
+        ++deliveries;
+        EXPECT_EQ(m,
+                  (midi::mixed_data_set{
+                    midi::manufacturer::universal_realtime, 0x0001, 0x0002, 0x0003, { 0xAE, 0xAF, 0xB0 } }));
+    };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // first chunk of two
+    c.feed({ 0x50870020, 0x00020001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD });
+    EXPECT_EQ(0u, deliveries);
+
+    // new single chunk mixed data set on the same mds id
+    c.feed({ 0x50870015, 0x00010001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+
+    EXPECT_EQ(1u, deliveries);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, header_only_final_chunk)
+{
+    using namespace midi;
+
+    // a sender that runs out of payload data terminates the mixed data set with a
+    // header only chunk (valid bytes = 16) declaring the final chunk counts
+    unsigned deliveries = 0;
+    auto     cb         = [&](const midi::mixed_data_set& m, uint4_t mds_id) {
+        ++deliveries;
+        EXPECT_EQ(0x1u, mds_id);
+        EXPECT_EQ(m, (midi::mixed_data_set{ midi::manufacturer::ableton, 0, 0, 0, { 0xDE, 0xAD, 0xBE, 0xEF } }));
+    };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // chunk 1, unknown number of chunks
+    c.feed({ 0x50810016, 0x00000001, 0xA11D0000, 0x00000000 });
+    c.feed({ 0x5091DEAD, 0xBEEF0000, 0, 0 });
+    EXPECT_EQ(0u, deliveries);
+
+    // final chunk 2 of 2, header bytes only
+    c.feed({ 0x50810010, 0x00020002, 0xA11D0000, 0x00000000 });
+    EXPECT_EQ(1u, deliveries);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, chunk_nr_beyond_nr_of_chunks)
+{
+    using namespace midi;
+
+    bool output_generated = false;
+    auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // chunk 1 of 2
+    c.feed({ 0x50870020, 0x00020001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD });
+
+    // contradictory header: chunk 2 of 1
+    c.feed({ 0x50870015, 0x00010002, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+    EXPECT_FALSE(output_generated);
+
+    // regular message on same mds id is collected afterwards
+    for (const auto& p : mixed_data_set_test_cases[3].packets)
+    {
+        c.feed(p);
+    }
+    EXPECT_TRUE(output_generated);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, valid_bytes_payload_underflow)
+{
+    using namespace midi;
+
+    bool output_generated = false;
+    auto cb               = [&](const midi::mixed_data_set&, uint4_t) { output_generated = true; };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    // valid bytes = 17 declares a payload packet with less than its two status bytes
+    c.feed({ 0x50870011, 0x00010001, 0x007F0001, 0x00020003 });
+    c.feed({ 0x5097AEAF, 0xB0000000, 0, 0 });
+    EXPECT_FALSE(output_generated);
+
+    // regular message on same mds id is collected afterwards
+    for (const auto& p : mixed_data_set_test_cases[3].packets)
+    {
+        c.feed(p);
+    }
+    EXPECT_TRUE(output_generated);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, stray_payload_between_chunks)
+{
+    using namespace midi;
+
+    // a payload packet between a completed chunk and the next chunk header is ignored
+    unsigned deliveries = 0;
+    auto     cb         = [&](const midi::mixed_data_set& m, uint4_t) {
+        ++deliveries;
+        EXPECT_EQ(m, mixed_data_set_test_cases[3].mds);
+    };
+
+    auto c = midi::mixed_data_set_collector{ cb };
+
+    const auto& packets = mixed_data_set_test_cases[3].packets; // "two chunks"
+
+    c.feed(packets[0]);                             // chunk 1 header
+    c.feed(packets[1]);                             // chunk 1 payload, chunk complete
+    c.feed({ 0x50971234, 0x56789ABC, 0xDEF00000 }); // stray payload packet
+    c.feed(packets[2]);                             // chunk 2 header
+    c.feed(packets[3]);                             // chunk 2 payload
+
+    EXPECT_EQ(1u, deliveries);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set_collector, no_callback)
+{
+    using namespace midi;
+
+    // a collector without callback safely swallows complete messages
+    auto c = midi::mixed_data_set_collector({});
+
+    for (const auto& entry : mixed_data_set_test_cases)
+    {
+        for (const auto& p : entry.packets)
+        {
+            c.feed(p);
+        }
+    }
+}

--- a/tests/mixed_data_set_test_data.cpp
+++ b/tests/mixed_data_set_test_data.cpp
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "mixed_data_set_test_data.h"
+
+#include <midi/manufacturer.h>
+
+//-----------------------------------------------
+
+std::vector<midi::mixed_data_set_test_case> midi::mixed_data_set_test_cases{
+    { "empty mixed data set (header only chunk)",
+      { { 0x50840010, 0x00010001, 0x007E1234, 0x00050006 } },
+      0x4,
+      midi::mixed_data_set{ midi::manufacturer::universal_non_realtime, 0x1234, 0x0005, 0x0006 } },
+    { "single payload packet",
+      { { 0x50800017, 0x00010001, 0xA1090000, 0x00000000 }, { 0x50901122, 0x33445500, 0, 0 } },
+      0x0,
+      midi::mixed_data_set{ midi::manufacturer::native_instruments, 0, 0, 0, { 0x11, 0x22, 0x33, 0x44, 0x55 } } },
+    { "two payload packets",
+      { { 0x508F0028, 0x00010001, 0x0004FFFF, 0x01020304 },
+        { 0x509F0102, 0x03040506, 0x0708090A, 0x0B0C0D0E },
+        { 0x509F0F10, 0x11121314, 0, 0 } },
+      0xF,
+      midi::mixed_data_set{ midi::manufacturer::moog, 0xFFFF, 0x0102, 0x0304, { 0x01, 0x02, 0x03, 0x04, 0x05,
+                                                                                0x06, 0x07, 0x08, 0x09, 0x0A,
+                                                                                0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                                                                                0x10, 0x11, 0x12, 0x13, 0x14 } } },
+    { "two chunks",
+      { { 0x50870020, 0x00020001, 0x007F0001, 0x00020003 },
+        { 0x5097A0A1, 0xA2A3A4A5, 0xA6A7A8A9, 0xAAABACAD },
+        { 0x50870015, 0x00020002, 0x007F0001, 0x00020003 },
+        { 0x5097AEAF, 0xB0000000, 0, 0 } },
+      0x7,
+      midi::mixed_data_set{
+        midi::manufacturer::universal_realtime,
+        0x0001,
+        0x0002,
+        0x0003,
+        { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0xB0 } } },
+    { "unknown number of chunks",
+      { { 0x50810016, 0x00000001, 0xA11D0000, 0x00000000 },
+        { 0x5091DEAD, 0xBEEF0000, 0, 0 },
+        { 0x50810014, 0x00020002, 0xA11D0000, 0x00000000 },
+        { 0x5091CAFE, 0, 0, 0 } },
+      0x1,
+      midi::mixed_data_set{ midi::manufacturer::ableton, 0, 0, 0, { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE } } }
+};

--- a/tests/mixed_data_set_test_data.h
+++ b/tests/mixed_data_set_test_data.h
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#pragma once
+
+#include <midi/mixed_data_set.h>
+
+#include <string>
+#include <vector>
+
+namespace midi {
+
+struct mixed_data_set_test_case
+{
+    std::string                   description;
+    std::vector<universal_packet> packets;
+    uint8_t                       mds_id;
+    mixed_data_set                mds;
+};
+
+extern std::vector<mixed_data_set_test_case> mixed_data_set_test_cases;
+
+} // namespace midi

--- a/tests/mixed_data_set_tests.cpp
+++ b/tests/mixed_data_set_tests.cpp
@@ -1,0 +1,272 @@
+//
+// Copyright (c) 2026 Native Instruments
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include <gtest/gtest.h>
+
+#include <midi/mixed_data_set.h>
+
+#include <midi/manufacturer.h>
+#include <midi/mixed_data_set_collector.h>
+
+#include "mixed_data_set_test_data.h"
+
+#include <numeric>
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, manufacturer_id_conversion)
+{
+    using namespace midi;
+
+    // one byte manufacturer IDs
+    EXPECT_EQ(0x0004u, mixed_data_set_manufacturer_id(manufacturer::moog));
+    EXPECT_EQ(0x007Eu, mixed_data_set_manufacturer_id(manufacturer::universal_non_realtime));
+    EXPECT_EQ(0x007Fu, mixed_data_set_manufacturer_id(manufacturer::universal_realtime));
+    EXPECT_EQ(0x0000u, mixed_data_set_manufacturer_id(0));
+
+    // three byte manufacturer IDs
+    EXPECT_EQ(0xA109u, mixed_data_set_manufacturer_id(manufacturer::native_instruments));
+    EXPECT_EQ(0x820Du, mixed_data_set_manufacturer_id(manufacturer::google));
+
+    // one byte manufacturer IDs
+    EXPECT_EQ(manufacturer::moog, manufacturer_from_mixed_data_set_id(0x0004));
+    EXPECT_EQ(manufacturer::universal_non_realtime, manufacturer_from_mixed_data_set_id(0x007E));
+    EXPECT_EQ(manufacturer::universal_realtime, manufacturer_from_mixed_data_set_id(0x007F));
+    EXPECT_EQ(0u, manufacturer_from_mixed_data_set_id(0x0000));
+
+    // three byte manufacturer IDs
+    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_mixed_data_set_id(0xA109));
+    EXPECT_EQ(manufacturer::google, manufacturer_from_mixed_data_set_id(0x820D));
+
+    // reserved bits are ignored
+    EXPECT_EQ(manufacturer::moog, manufacturer_from_mixed_data_set_id(0x0084));
+    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_mixed_data_set_id(0xA189));
+
+    // round trip
+    for (const auto m : { manufacturer::moog, manufacturer::universal_realtime, manufacturer::native_instruments })
+    {
+        EXPECT_EQ(m, manufacturer_from_mixed_data_set_id(mixed_data_set_manufacturer_id(m)));
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, constructors)
+{
+    using namespace midi;
+
+    {
+        mixed_data_set m;
+        EXPECT_EQ(0u, m.manufacturerID);
+        EXPECT_EQ(0u, m.deviceID);
+        EXPECT_EQ(0u, m.subID1);
+        EXPECT_EQ(0u, m.subID2);
+        EXPECT_TRUE(m.data.empty());
+    }
+
+    {
+        mixed_data_set m{ manufacturer::native_instruments };
+        EXPECT_EQ(manufacturer::native_instruments, m.manufacturerID);
+        EXPECT_EQ(0u, m.deviceID);
+        EXPECT_TRUE(m.data.empty());
+    }
+
+    {
+        mixed_data_set m{ manufacturer::moog, 0xFFFF, 0x0102, 0x0304 };
+        EXPECT_EQ(manufacturer::moog, m.manufacturerID);
+        EXPECT_EQ(0xFFFFu, m.deviceID);
+        EXPECT_EQ(0x0102u, m.subID1);
+        EXPECT_EQ(0x0304u, m.subID2);
+        EXPECT_TRUE(m.data.empty());
+    }
+
+    {
+        mixed_data_set m{ manufacturer::moog, 1, 2, 3, { 0xAA, 0xBB, 0xCC } };
+        EXPECT_EQ(manufacturer::moog, m.manufacturerID);
+        EXPECT_EQ((mixed_data_set::data_type{ 0xAA, 0xBB, 0xCC }), m.data);
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, equality)
+{
+    using namespace midi;
+
+    const mixed_data_set a{ manufacturer::moog, 1, 2, 3, { 0xAA, 0xBB } };
+
+    EXPECT_EQ(a, a);
+    EXPECT_EQ(a, (mixed_data_set{ manufacturer::moog, 1, 2, 3, { 0xAA, 0xBB } }));
+
+    EXPECT_NE(a, (mixed_data_set{ manufacturer::google, 1, 2, 3, { 0xAA, 0xBB } }));
+    EXPECT_NE(a, (mixed_data_set{ manufacturer::moog, 9, 2, 3, { 0xAA, 0xBB } }));
+    EXPECT_NE(a, (mixed_data_set{ manufacturer::moog, 1, 9, 3, { 0xAA, 0xBB } }));
+    EXPECT_NE(a, (mixed_data_set{ manufacturer::moog, 1, 2, 9, { 0xAA, 0xBB } }));
+    EXPECT_NE(a, (mixed_data_set{ manufacturer::moog, 1, 2, 3, { 0xAA } }));
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, clear)
+{
+    using namespace midi;
+
+    mixed_data_set m{ manufacturer::moog, 1, 2, 3, { 0xAA, 0xBB } };
+    m.clear();
+
+    EXPECT_EQ(m, mixed_data_set{});
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, as_mixed_data_set_packets)
+{
+    using namespace midi;
+
+    // empty mixed data set results in a single header only chunk
+    {
+        const mixed_data_set m{ manufacturer::universal_non_realtime, 0x1234, 0x0005, 0x0006 };
+
+        const auto packets = as_mixed_data_set_packets(m, 0x4);
+
+        ASSERT_EQ(1u, packets.size());
+        EXPECT_EQ(universal_packet(0x50840010, 0x00010001, 0x007E1234, 0x00050006), packets[0]);
+    }
+
+    // single payload packet
+    {
+        const mixed_data_set m{ manufacturer::native_instruments, 0, 0, 0, { 0x11, 0x22, 0x33, 0x44, 0x55 } };
+
+        const auto packets = as_mixed_data_set_packets(m, 0x0);
+
+        ASSERT_EQ(2u, packets.size());
+        EXPECT_EQ(universal_packet(0x50800017, 0x00010001, 0xA1090000, 0x00000000), packets[0]);
+        EXPECT_EQ(universal_packet(0x50901122, 0x33445500, 0, 0), packets[1]);
+    }
+
+    // two payload packets, non-zero group
+    {
+        const mixed_data_set m{ manufacturer::moog, 0xFFFF, 0x0102, 0x0304, { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                                                                              0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+                                                                              0x0F, 0x10, 0x11, 0x12, 0x13, 0x14 } };
+
+        const auto packets = as_mixed_data_set_packets(m, 0xF, 0x3);
+
+        ASSERT_EQ(3u, packets.size());
+        EXPECT_EQ(universal_packet(0x538F0028, 0x00010001, 0x0004FFFF, 0x01020304), packets[0]);
+        EXPECT_EQ(universal_packet(0x539F0102, 0x03040506, 0x0708090A, 0x0B0C0D0E), packets[1]);
+        EXPECT_EQ(universal_packet(0x539F0F10, 0x11121314, 0, 0), packets[2]);
+    }
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, send_mixed_data_set_multiple_chunks)
+{
+    using namespace midi;
+
+    // a chunk carries at most 4094 payload packets of 14 bytes
+    constexpr size_t max_chunk_data_size = 4094 * 14;
+
+    mixed_data_set m{ manufacturer::native_instruments, 0, 0, 0 };
+    m.data.resize(max_chunk_data_size + 5);
+    std::iota(m.data.begin(), m.data.end(), uint8_t{ 0 });
+
+    unsigned headers  = 0;
+    unsigned payloads = 0;
+    send_mixed_data_set(m, 0x2, 0, [&](const universal_packet& p) {
+        if (is_mixed_data_set_header_packet(p))
+        {
+            const auto h = mixed_data_set_header_packet_view{ p };
+            EXPECT_EQ(0x2u, h.mds_id());
+            EXPECT_EQ(2u, h.nr_of_chunks());
+            EXPECT_EQ(headers + 1, h.chunk_nr());
+            EXPECT_EQ(0xA109u, h.manufacturer_id());
+
+            if (headers == 0)
+            {
+                // full chunk: 16 header bytes plus 4094 full payload packets
+                EXPECT_EQ(16u + 16u * 4094u, h.valid_bytes_in_chunk());
+            }
+            else
+            {
+                // remainder: 16 header bytes plus one payload packet with 5 valid bytes
+                EXPECT_EQ(16u + 2u + 5u, h.valid_bytes_in_chunk());
+            }
+            ++headers;
+        }
+        else
+        {
+            EXPECT_TRUE(is_mixed_data_set_payload_packet(p));
+            ++payloads;
+        }
+    });
+
+    EXPECT_EQ(2u, headers);
+    EXPECT_EQ(4094u + 1u, payloads);
+}
+
+//-----------------------------------------------
+
+TEST(mixed_data_set, send_mixed_data_set_exact_chunk_boundary)
+{
+    using namespace midi;
+
+    // data of exactly one maximum size chunk results in a single chunk
+    constexpr size_t max_chunk_data_size = 4094 * 14;
+
+    mixed_data_set m{ manufacturer::native_instruments, 0, 0, 0 };
+    m.data.resize(max_chunk_data_size);
+    std::iota(m.data.begin(), m.data.end(), uint8_t{ 0 });
+
+    unsigned headers  = 0;
+    unsigned payloads = 0;
+    send_mixed_data_set(m, 0x0, 0, [&](const universal_packet& p) {
+        if (is_mixed_data_set_header_packet(p))
+        {
+            const auto h = mixed_data_set_header_packet_view{ p };
+            EXPECT_EQ(1u, h.nr_of_chunks());
+            EXPECT_EQ(1u, h.chunk_nr());
+            EXPECT_EQ(16u + 16u * 4094u, h.valid_bytes_in_chunk());
+            ++headers;
+        }
+        else
+        {
+            ++payloads;
+        }
+    });
+
+    EXPECT_EQ(1u, headers);
+    EXPECT_EQ(4094u, payloads);
+
+    // and roundtrips through the collector
+    bool collected = false;
+    auto c         = midi::mixed_data_set_collector{ [&](const midi::mixed_data_set& result, uint4_t) {
+        collected = true;
+        EXPECT_EQ(result, m);
+    } };
+    for (const auto& p : as_mixed_data_set_packets(m, 0x0))
+    {
+        c.feed(p);
+    }
+    EXPECT_TRUE(collected);
+}

--- a/tests/mixed_data_set_tests.cpp
+++ b/tests/mixed_data_set_tests.cpp
@@ -38,33 +38,33 @@ TEST(mixed_data_set, manufacturer_id_conversion)
     using namespace midi;
 
     // one byte manufacturer IDs
-    EXPECT_EQ(0x0004u, mixed_data_set_manufacturer_id(manufacturer::moog));
-    EXPECT_EQ(0x007Eu, mixed_data_set_manufacturer_id(manufacturer::universal_non_realtime));
-    EXPECT_EQ(0x007Fu, mixed_data_set_manufacturer_id(manufacturer::universal_realtime));
-    EXPECT_EQ(0x0000u, mixed_data_set_manufacturer_id(0));
+    EXPECT_EQ(0x0004u, manufacturer_id_16bit(manufacturer::moog));
+    EXPECT_EQ(0x007Eu, manufacturer_id_16bit(manufacturer::universal_non_realtime));
+    EXPECT_EQ(0x007Fu, manufacturer_id_16bit(manufacturer::universal_realtime));
+    EXPECT_EQ(0x0000u, manufacturer_id_16bit(0));
 
     // three byte manufacturer IDs
-    EXPECT_EQ(0xA109u, mixed_data_set_manufacturer_id(manufacturer::native_instruments));
-    EXPECT_EQ(0x820Du, mixed_data_set_manufacturer_id(manufacturer::google));
+    EXPECT_EQ(0xA109u, manufacturer_id_16bit(manufacturer::native_instruments));
+    EXPECT_EQ(0x820Du, manufacturer_id_16bit(manufacturer::google));
 
     // one byte manufacturer IDs
-    EXPECT_EQ(manufacturer::moog, manufacturer_from_mixed_data_set_id(0x0004));
-    EXPECT_EQ(manufacturer::universal_non_realtime, manufacturer_from_mixed_data_set_id(0x007E));
-    EXPECT_EQ(manufacturer::universal_realtime, manufacturer_from_mixed_data_set_id(0x007F));
-    EXPECT_EQ(0u, manufacturer_from_mixed_data_set_id(0x0000));
+    EXPECT_EQ(manufacturer::moog, manufacturer_from_16bit_id(0x0004));
+    EXPECT_EQ(manufacturer::universal_non_realtime, manufacturer_from_16bit_id(0x007E));
+    EXPECT_EQ(manufacturer::universal_realtime, manufacturer_from_16bit_id(0x007F));
+    EXPECT_EQ(0u, manufacturer_from_16bit_id(0x0000));
 
     // three byte manufacturer IDs
-    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_mixed_data_set_id(0xA109));
-    EXPECT_EQ(manufacturer::google, manufacturer_from_mixed_data_set_id(0x820D));
+    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_16bit_id(0xA109));
+    EXPECT_EQ(manufacturer::google, manufacturer_from_16bit_id(0x820D));
 
     // reserved bits are ignored
-    EXPECT_EQ(manufacturer::moog, manufacturer_from_mixed_data_set_id(0x0084));
-    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_mixed_data_set_id(0xA189));
+    EXPECT_EQ(manufacturer::moog, manufacturer_from_16bit_id(0x0084));
+    EXPECT_EQ(manufacturer::native_instruments, manufacturer_from_16bit_id(0xA189));
 
     // round trip
     for (const auto m : { manufacturer::moog, manufacturer::universal_realtime, manufacturer::native_instruments })
     {
-        EXPECT_EQ(m, manufacturer_from_mixed_data_set_id(mixed_data_set_manufacturer_id(m)));
+        EXPECT_EQ(m, manufacturer_from_16bit_id(manufacturer_id_16bit(m)));
     }
 }
 


### PR DESCRIPTION
Adds Mixed Data Set (MT=0x5, MDS) message support following the sysex API:

* mixed_data_set_header_packet / mixed_data_set_payload_packet packet types in extended_data_message.h, with views, is_* predicates and factories
* mixed_data_set data structure (sharing the sysex data allocator config) with send_mixed_data_set / as_mixed_data_set_packets, spec-correct chunking per M2-104 section 7.9 (16-bit sub-IDs, valid-byte count including header)
* mixed_data_set_collector reassembling Mixed Data Sets from incoming packets, with up to 16 simultaneous mds_ids, abort, unknown chunk count and out-of-order handling
* unit tests, docs and examples